### PR TITLE
Fix default filename for prediction

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,5 +27,7 @@ Next, run
 ```python
 python main.py -predict_df -modelname SSD_models/student35  # any models in the 'model_files' folder can be read for the prediction.
 ```
+The script looks for `molecules_to_predict.csv` by default. If your file has a
+different name, pass it via `-filename <your_file.csv>`.
 
 Then, a user can find 'molecules_to_predict_results.csv' file which contains the predicted Gibbs free energies of solvation. ('predicted' column)

--- a/main.py
+++ b/main.py
@@ -338,7 +338,8 @@ if __name__ == '__main__':
     parser.add_argument('-chunk_number', type=int, default=0, help='in case one wants to predict a chunk of 10,000 data points among a huge number of data points (>10^4)')
     parser.add_argument('-dropout', type=float, default=0.0, help='default=0.0')
     parser.add_argument('-surv_prob', type=float, default=1.0, help='default=1.0')
-    parser.add_argument('-filename', type=str, help='filename')
+    parser.add_argument('-filename', type=str, default='molecules_to_predict.csv',
+                        help='input CSV file for prediction (default=molecules_to_predict.csv)')
     args = parser.parse_args()
 
     tic = time.perf_counter()


### PR DESCRIPTION
## Summary
- set default `-filename` argument to `molecules_to_predict.csv`
- mention optional `-filename` in README

## Testing
- `python -m py_compile main.py gnn.py`

------
https://chatgpt.com/codex/tasks/task_e_68530447cc6c8329922486f616ddf6fb