### PR TITLE
Add notebook to compare embedding distributions

### DIFF
--- a/notebooks/embedding_comparison.ipynb
+++ b/notebooks/embedding_comparison.ipynb
@@ -1,0 +1,102 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Compare embedding distribution\n",
+    "This notebook computes the model embeddings for two data sets and visualises their distributions with t-SNE."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "from gnn import create_tf_dataset, CustomPreprocessor, atom_features, bond_features, global_features\n",
+    "import tensorflow as tf\n",
+    "import nfp\n",
+    "from sklearn.decomposition import PCA\n",
+    "from sklearn.manifold import TSNE\n",
+    "from sklearn.pipeline import Pipeline\n",
+    "import numpy as np\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load the data\n",
+    "df_aug = pd.read_csv('data/Aug-DBs/Aug-DB1.csv')\n",
+    "# dff2 path comes from notebooks/data.py.ipynb\n",
+    "dff2 = pd.read_csv('/home/nanta/Redox_mediator_screening/data/Filtered_data/filter2.csv.gz', compression='gzip')\n",
+    "df_aug = df_aug[['can_smiles_solute','can_smiles_solvent','DGsolv']]\n",
+    "dff2 = dff2[['can_smiles_solute','can_smiles_solvent','DGsolv']]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Load model and preprocessor\n",
+    "model = tf.keras.models.load_model('model_files/SSD_models/student35/best_model.h5', custom_objects=nfp.custom_objects)\n",
+    "preprocessor = CustomPreprocessor(explicit_hs=False, atom_features=atom_features, bond_features=bond_features)\n",
+    "preprocessor.from_json('model_files/SSD_models/student35/preprocessor.json')\n",
+    "\n",
+    "extractor = tf.keras.Model(model.inputs, [model.layers[-1].input])\n",
+    "output_signature = (preprocessor.output_signature, tf.TensorSpec(shape=(), dtype=tf.float32), tf.TensorSpec(shape=(), dtype=tf.float32))\n",
+    "\n",
+    "def embed_dataframe(df):\n",
+    "    ds = tf.data.Dataset.from_generator(\n",
+    "        lambda: create_tf_dataset(df, preprocessor, 1.0, False),\n",
+    "        output_signature=output_signature\n",
+    "    ).padded_batch(batch_size=len(df))\n",
+    "    return extractor.predict(ds).squeeze()\n",
+    "\n",
+    "emb_aug = embed_dataframe(df_aug)\n",
+    "emb_dff2 = embed_dataframe(dff2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# t-SNE comparison\n",
+    "all_emb = np.concatenate([emb_aug, emb_dff2])\n",
+    "labels = np.array([0]*len(emb_aug) + [1]*len(emb_dff2))\n",
+    "pipe = Pipeline(steps=[('PCA', PCA(n_components=10)), ('TSNE', TSNE(n_components=2, random_state=0))])\n",
+    "tsne_coords = pipe.fit_transform(all_emb)\n",
+    "plt.figure(figsize=(6,5))\n",
+    "plt.scatter(tsne_coords[labels==0,0], tsne_coords[labels==0,1], s=10, label='Aug-DB1')\n",
+    "plt.scatter(tsne_coords[labels==1,0], tsne_coords[labels==1,1], s=10, label='dff2')\n",
+    "plt.legend()\n",
+    "plt.xlabel('t-SNE 1')\n",
+    "plt.ylabel('t-SNE 2')\n",
+    "plt.title('Embedding distribution comparison')\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "pygments_lexer": "ipython3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- add a new notebook `embedding_comparison.ipynb`
- notebook loads Aug-DB1 and `dff2` data, computes model embeddings and uses t-SNE to visualize distribution differences

## Testing
- `python -m pytest` *(fails: ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_e_68530aaed27883298348295ded0f14d4